### PR TITLE
Clarifying difference between functions

### DIFF
--- a/src/tests/test01.vtc
+++ b/src/tests/test01.vtc
@@ -9,7 +9,7 @@ varnish v1 -vcl+backend {
 	import cowsay from "${vmod_topbuild}/src/.libs/libvmod_cowsay.so";
 	sub vcl_recv {
 	    if (req.url ~ "/gimmethecow") {
-	       	set req.http.x-cow = cowsay.cowsay_header();
+	       	set req.http.x-cow = cowsay.cowsay_canonical();
 	    	}
 	}
 

--- a/src/tests/test03.vtc
+++ b/src/tests/test03.vtc
@@ -1,4 +1,4 @@
-varnishtest "Test cowsay synth"
+varnishtest "Test cowsay friends"
 
 server s1 {
        rxreq
@@ -9,7 +9,7 @@ varnish v1 -vcl+backend {
 	import cowsay from "${vmod_topbuild}/src/.libs/libvmod_cowsay.so";
 	
 	sub vcl_recv {
-		if (req.url ~ "/cowsay") {
+		if (req.url ~ "/cowsay-friends") {
 			return(synth(700, "OK"));
 		}
 	}
@@ -18,7 +18,7 @@ varnish v1 -vcl+backend {
 		if (resp.status == 700) {
 			set resp.status = 200;
 			set resp.http.Content-Type = "text/plain; charset=utf-8";
-			synthetic(cowsay.cowsay_vsb());
+			synthetic(cowsay.cowsay_friends("bunny", "ciao"));
 			return (deliver);
 			}
 		}
@@ -26,6 +26,6 @@ varnish v1 -vcl+backend {
 } -start
 
 client c1 {
-	txreq -url "/cowsay"
+	txreq -url "/cowsay-friends"
 	rxresp
 } -run

--- a/src/vmod_cowsay.c
+++ b/src/vmod_cowsay.c
@@ -28,7 +28,7 @@ init_function(struct vmod_priv *priv, const struct VCL_conf *conf)
 }
 
 VCL_STRING
-vmod_cowsay_header(VRT_CTX)
+vmod_cowsay_canonical(VRT_CTX)
 {
 	char *p;
 	unsigned u, v;
@@ -60,17 +60,15 @@ vmod_cowsay_header(VRT_CTX)
 }
 
 VCL_STRING
-vmod_cowsay_synth(VRT_CTX)
+vmod_cowsay_vsb(VRT_CTX)
 {
-	/* This vmod functions show you how to create response bodies
-	   intended as synthetic objects. This functions must be called
-	   from vcl_synth and doesn't make any sense if called from any
-	   other vcl subroutines. Give a look at the VCL workflow */
+	/* This VMOD function shows you how to create response bodies
+	   intended as synthetic objects. */
 
         unsigned  u;
         struct vsb *vsb;
         u = WS_Reserve(ctx->ws, 0);
-	/* vsb.h is a very nice varnish library for manipulating strings,
+	/* vsb.h is a very useful varnish library for manipulating strings,
 	   use it instead of the canonical string libraries  */
         vsb = VSB_new(NULL, ctx->ws->f, u, VSB_AUTOEXTEND);
 	VSB_printf(vsb, "** body **\n");

--- a/src/vmod_cowsay.vcc
+++ b/src/vmod_cowsay.vcc
@@ -21,14 +21,24 @@ You can even have links and lists in here:
 The init-function declared next does not need documentation.
 $Init init_function
 
-$Function STRING cowsay_header()
-	This function returns a cow header, it is available
-	from every vcl subruotines.
+$Function STRING cowsay_canonical()
 
-$Function STRING cowsay_synth()
-	This function returs a cow as response body, created as
-	synthetic object.
+	Returns cowsay ASCII picture using canonical string libraries.
+	The output of this function is to be assigned to: 1) HTTP
+	header fields in vcl_recv and vcl_deliver, or 2) HTTP message
+	bodies in vcl_synth
 
-$Function STRING cowsay_friends(STRING, STRING)
-	This functions let's you decide if you want a cow or a bunny
-	and what you want them to "say".
+$Function STRING cowsay_vsb()
+
+	Returns cowsay ASCII picture using the Varnish String Buffer
+	(VSB) library.  The output of this function is to be assigned
+	to: 1) HTTP header fields in vcl_recv and vcl_deliver, or 2)
+	HTTP message bodies in vcl_synth
+
+$Function STRING cowsay_friends(STRING, STRING)	     
+        Returns a particular animal ASCII picture that says a message.
+	The first argument is the animal figure, and the second is the
+	message to be said.  This function uses the Varnish String
+	Buffer (VSB) library and its output is to be assigned to: 1)
+	HTTP header fields in vcl_recv and vcl_deliver, or 2) HTTP
+	message bodies in vcl_synth


### PR DESCRIPTION
Clarifies in `vmod_cowsay.vcc` that the functions of this VMOD manipulate strings using canonical or VSB libraries.
The string manipulation library used is independent from how output string is going to be used.
That is, both libraries can be used to be assigned to HTTP header fields or body messages.
